### PR TITLE
jenkins: Use a perl regexp for the mpirun versio

### DIFF
--- a/jenkins/open-mpi-build-script.sh
+++ b/jenkins/open-mpi-build-script.sh
@@ -214,7 +214,9 @@ run_example() {
 if test "${MPIRUN_MODE}" != "none"; then
     echo "--> running examples"
     echo "localhost cpu=2" > "${WORKSPACE}/hostfile"
-    mpirun_version=`"${WORKSPACE}/install/bin/mpirun" --version | sed -n 's/.*\([0-9]\+\.[0-9]\+\)\..*/\1/p'`
+    # Note: using perl here because figuring out a portable sed regexp
+    # proved to be a little challenging.
+    mpirun_version=`"${WORKSPACE}/install/bin/mpirun --version | perl -wnE 'say $1 if /mpirun [^\d]*(\d+.\d+)/'`
     echo "--> mpirun version: ${mpirun_version}"
     case ${mpirun_version} in
 	1.*|2.0*)


### PR DESCRIPTION
The sed regexp is a bit challenging to make portable (e.g., what works
on Linux may not work in OS X / BSDs).  So just switch to Perl,
because Perl's regexps are nicely uniform across platforms.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>