### PR TITLE
jenkins: Include 32 bit builds on Ubuntu AMI

### DIFF
--- a/jenkins/customize-ami.sh
+++ b/jenkins/customize-ami.sh
@@ -112,8 +112,9 @@ case $PLATFORM_ID in
 		sudo apt-get -y install gcc-4.7 g++-4.7 gfortran-4.7 \
 		     gcc-4.8 g++-4.8 gfortran-4.8 \
 		     gcc-4.9 g++-4.9 gfortran-4.9 \
-		     clang-3.6 clang-3.7 clang-3.8
-		labels="${labels} gcc47 gcc48 gcc49 gcc5 clang36 clang37 clang38"
+		     clang-3.6 clang-3.7 clang-3.8 \
+		     gcc-multilib g++-multilib gfortran-multilib
+		labels="${labels} gcc47 gcc48 gcc49 gcc5 clang36 clang37 clang38 32bit_builds"
 		;;
 	    *)
 		echo "ERROR: Unknown version ${PLATFORM_ID} ${VERSION_ID}"


### PR DESCRIPTION
The AMIs built in December included the 32 bit packages, but
apparently the build script in git never included them.  Sigh.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>