### PR TITLE
dist upload: fix conditional to choose autodetect

### DIFF
--- a/dist/upload-release-to-s3.py
+++ b/dist/upload-release-to-s3.py
@@ -94,8 +94,8 @@ if len(args_dict['files']) < 1:
     print('No files specified.  Stopping.')
     exit(1)
 
-if (args_dict['project'] == None and args_dict['branch'] == None
-    and args_dict['version'] == None) and args_dict['date'] == None:
+if (args_dict['project'] == None or args_dict['branch'] == None
+    or args_dict['version'] == None) or args_dict['date'] == None:
     if args_dict['yes']:
         print('Can not use --yes option unless --project, --branch, --version, ' +
               'and --date are also set.')


### PR DESCRIPTION
There was an error in the conditional to determine if the
upload-release-to-s3 script needed to auto-detect any of the
configuration options (project, branch, version, date).  This
commit fixes that logic so that the script works even when
all four arguments aren't specified.

tl;dr: "or", not "and"

Signed-off-by: Brian Barrett <bbarrett@amazon.com>