### PR TITLE
Add script to test for tabs in commit range

### DIFF
--- a/jenkins/whitespace-checker.sh
+++ b/jenkins/whitespace-checker.sh
@@ -13,11 +13,11 @@ config_file=.whitespace-checker-config.txt
 if [[ -r $config_file ]]; then
     exclude_dirs=`cat $config_file`
 else
-    exclude_dirs='hwloc|libevent|pmix4x|treematch|romio'
+    exclude_dirs='((opal/mca/hwloc/hwloc.*/hwloc)|/(libevent|pmix4x|treematch|romio))/'
 fi
 
 foundTab=0
-for file in $(git diff --name-only $1 $2 | grep -vE "/($exclude_dirs)/" | grep -E "(\.c|\.h)$")
+for file in $(git diff -l0 --name-only $1 $2 | grep -vE "($exclude_dirs)" | grep -E "(\.c|\.h)$")
 do
     git diff $1 $2 -- $file | grep -C $context -E "^\+.*	+"
     if [[ $? -eq 0 ]]

--- a/jenkins/whitespace-checker.sh
+++ b/jenkins/whitespace-checker.sh
@@ -1,0 +1,32 @@
+#! /usr/bin/env bash
+#
+# Copyright (c) 2019      Hewlett Packard Enterprise. All Rights Reserved.
+#
+# Additional copyrights may follow
+#
+# Check for white space violation in a given commit range.
+# Run on a PR to check whether it is introducing bad white space.
+#
+
+context=3
+config_file=.whitespace-checker-config.txt
+if [[ -r $config_file ]]; then
+    exclude_dirs=`cat $config_file`
+else
+    exclude_dirs='hwloc|libevent|pmix4x|treematch|romio'
+fi
+
+foundTab=0
+for file in $(git diff --name-only $1 $2 | grep -vE "/($exclude_dirs)/" | grep -E "(\.c|\.h)$")
+do
+    git diff $1 $2 -- $file | grep -C $context -E "^\+.*	+"
+    if [[ $? -eq 0 ]]
+    then
+        foundTab=1
+    fi
+done
+
+if [[ $foundTab -ne 0 ]]
+then
+    exit 1
+fi


### PR DESCRIPTION
In order to prevent violations of the coding style in ompi it was
decided to check any future PRs for white space violations. This script
checks whether a certain commit range has introduced a tab character.

See open-mpi/ompi#6831 for details.

Signed-off-by: guserav <erik.zeiske@hpe.com>