### PR TITLE
nightly: Properly handle submodules

### DIFF
--- a/nightly-tarball/Builder.py
+++ b/nightly-tarball/Builder.py
@@ -378,6 +378,9 @@ class Builder(object):
             repo.git.checkout('origin/' + branch, b=branch)
         repo.head.reference = repo.refs['origin/' + branch]
 
+        # And pull in all the right submodules
+        repo.submodule_update(recursive = True)
+
         # wish I could figure out how to do this without resorting to
         # shelling out to git :/
         self._current_build['revision'] = repo.git.rev_parse(repo.head.object.hexsha, short=7)


### PR DESCRIPTION
Open MPI now uses submodules for some components (hwloc, with more
to follow shortly).  The nightly builder needs to pull all relevant
submodules in the repository for a build to succeed.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>