### PR TITLE
jenkins: "mpirun -hostfile" is no longer accepted

### DIFF
--- a/jenkins/open-mpi-build-script.sh
+++ b/jenkins/open-mpi-build-script.sh
@@ -249,7 +249,7 @@ if test "${MPIRUN_MODE}" != "none"; then
 	    exec="timeout -s SIGSEGV 3m mpirun -hostfile ${WORKSPACE}/hostfile -np 2 "
 	    ;;
 	*)
-	    exec="timeout -s SIGSEGV 4m mpirun --get-stack-traces --timeout 180 -hostfile ${WORKSPACE}/hostfile -np 2 "
+	    exec="timeout -s SIGSEGV 4m mpirun --get-stack-traces --timeout 180 --hostfile ${WORKSPACE}/hostfile -np 2 "
 	    ;;
     esac
     run_example "${exec}" ./examples/hello_c


### PR DESCRIPTION
PRRTE only accepts --hostfile (not -hostfile).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>