### PR TITLE
dist: Update uploader to support Python 3

### DIFF
--- a/dist/upload-release-to-s3.py
+++ b/dist/upload-release-to-s3.py
@@ -26,7 +26,11 @@
 import argparse
 import boto3
 import botocore
-import urlparse
+# stupid python versions
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 import sys
 import re
 import os
@@ -83,7 +87,7 @@ args = parser.parse_args()
 args_dict = vars(args)
 
 # split the s3 URL into bucket and path, which is what Boto3 expects
-parts = urlparse.urlparse(args_dict['s3_base'])
+parts = urlparse(args_dict['s3_base'])
 if parts.scheme != 's3':
     print('unexpected URL format for s3-base.  Expected scheme s3, got %s' % parts.scheme)
     exit(1)

--- a/dist/uploadutils.py
+++ b/dist/uploadutils.py
@@ -8,14 +8,13 @@
 
 import boto3
 import botocore
-import urlparse
 import sys
 import re
 import os
 import json
 import tarfile
 import hashlib
-import StringIO
+from io import StringIO
 import datetime
 import unittest
 import mock
@@ -474,7 +473,7 @@ class upload_files_tests(unittest.TestCase):
             fileinfo['md5'] = 'zyx'
             fileinfo['size'] = 1024
             buildinfo['files']['openmpi-100.0.0rho1.tar.bz2'] = fileinfo
-            result['Body'] = StringIO.StringIO(json.dumps(buildinfo))
+            result['Body'] = StringIO(json.dumps(buildinfo))
 
             return result
 


### PR DESCRIPTION
With Ubuntu 20.04 only supporting Python 3, it is time
to make all our code support either Python 2 or Python 3.
Start with the uploader script.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>