### PR TITLE
jenkins: Add commit email/signed-off-by check jobs

### DIFF
--- a/jenkins/commit-email-checker.py
+++ b/jenkins/commit-email-checker.py
@@ -27,11 +27,11 @@ def _email_address_checker(commit, results):
         if ('root@' in email or
             'localhost' in email or
             'localdomain' in email):
-            logging.error(f"Commit {commit.hexsha} has an unspecific {type} email address: {email}")
+            logging.error("Commit %s has an unspecific %s email address: %s" % (commit.hexsha, type, email))
             results['bad'] += 1
 
         else:
-            logging.info(f"Commit {commit.hexsha} has a good {type} email address: {email}")
+            logging.info("Commit %s has a good %s email address: %s" % (commit.hexsha, type, email))
             results['good'] += 1
 
 #--------------------------------------

--- a/jenkins/open-mpi.pr.command-runner.groovy
+++ b/jenkins/open-mpi.pr.command-runner.groovy
@@ -1,0 +1,91 @@
+// -*- groovy -*-
+//
+// Run a python script on a PR commit series to check
+// for things like signed-off-by or commit emails.
+//
+//
+// WORKSPACE Layout:
+//   srcdir/               PR checking source tree
+//   ompi-scripts/         ompi-scripts master checkout
+
+def builder_label = "headnode"
+def pr_context = env.context_name
+def script_name = "ompi-scripts/" + env.script_name
+def target_srcdir = "srcdir"
+
+// Start by immediately tagging this as in progress...
+setGitHubPullRequestStatus(context: pr_context, message: 'In progress', state: 'PENDING')
+
+node(builder_label) {
+  stage('Source Checkout') {
+    try {
+      checkout_code(target_srcdir);
+    } catch (err) {
+      setGitHubPullRequestStatus(context: pr_context,
+                                 message: "Internal Accounting Error",
+                                 state: 'ERROR')
+      throw(err)
+    }
+  }
+
+  stage('Checking git commits'){
+    // There's no way to capture the stdout when the script fails,
+    // so we have the script dump any output we want to use as the status
+    // message in a file that is slurped up later.
+    ret = sh(script: "python ${script_name} --status-msg-file checker-output.txt --gitdir ${target_srcdir} --base-branch origin/${env.GITHUB_PR_TARGET_BRANCH} --pr-branch origin/PR-${env.GITHUB_PR_NUMBER}",
+             returnStatus: true)
+    echo "script return code: ${ret}"
+
+    // GitHub has three status states:
+    //   SUCCESS - everything is good
+    //   FAILURE - the tests functioned, but did not pass
+    //   ERROR - the tests did not function
+    // We expect script error code 0 to map to SUCCESS, 1 to map to
+    // FAILURE, and all others map to error.  We do not expect to have
+    // a useful status message on FAILURE.
+    if (ret == 0 || ret == 1) {
+      status_string = sh(script: "cat checker-output.txt", returnStdout: true)
+      status_string = status_string.trim()
+      if (ret == 0) {
+        status_state = 'SUCCESS'
+      } else {
+        status_state = 'FAILURE'
+      }
+    } else {
+      status_string = "Internal Accounting Error"
+      status_state = 'ERROR'
+    }
+
+    setGitHubPullRequestStatus(context: pr_context,
+                               message: "${status_string}",
+                               state: "${status_state}")
+
+    if (ret != 0) {
+      currentBuild.result = 'FAILURE'
+    }
+  }
+}
+
+
+def checkout_code(target_srcdir) {
+  pr_num = env.GITHUB_PR_NUMBER
+
+  // Pull the refspecs for all the origin branches, as well as the PR
+  // in question.  We could be more specific with origin branches, but
+  // that would be more work for only a little space savings.
+  checkout(changelog: false, poll: false,
+           scm: [$class: 'GitSCM',
+                  extensions: [[$class: 'RelativeTargetDirectory',
+                               relativeTargetDir: "${target_srcdir}"]],
+                 userRemoteConfigs: [[credentialsId: '6de58bf1-2619-4065-99bb-8d284b4691ce',
+                                      refspec: "+refs/pull/${pr_num}/head:refs/remotes/origin/PR-${pr_num} +refs/heads/*:refs/remotes/origin/*",
+                                      url: "${env.GITHUB_REPO_GIT_URL}"]]])
+
+  // Make sure we have the ompi-scripts repository on the build node as well.
+  // scm is a provided global variable that points to the repository
+  // configured in the Jenkins job for the pipeline source.  Since the
+  // pipeline and the helper scripts live in the same place, this is
+  // perfect for us.  We check this out on the worker nodes so that
+  // the helper scripts are always available.
+  checkout(changelog: false, poll: false, scm: scm)
+}

--- a/jenkins/signed-off-by-checker.py
+++ b/jenkins/signed-off-by-checker.py
@@ -27,19 +27,19 @@ _prog = re.compile("^Signed-off-by: (.+?) <(.+)>$",
 def _signed_off_by_checker(commit, results):
     # Ignore merge commits
     if len(commit.parents) > 1:
-        loggging.info(f"Merge commit {commit.hexsha} skipped")
+        loggging.info("Merge commit %s skipped" % (commit.hexsha))
         return
 
     match = _prog.search(commit.message)
     if not match:
         results['bad'] += 1
-        logging.error("Commit {commit.hexsha} not signed off")
+        logging.error("Commit %s not signed off" % (commit.hexsha))
 
     else:
         results['good'] += 1
         name = match.group(1)
         addr = match.group(2)
-        logging.info(f"Commit {commit.hexsha} properly signed off: {name} <{addr}>")
+        logging.info("Commit %s properly signed off: %s <%s>" % (commit.hexsha, name, addr))
 
 #--------------------------------------
 # Call the main engine


### PR DESCRIPTION
We are trying to migrate our commit email and signed off by
checkers from PHP invoked directly from the GitHub hooks to
Jenkins jobs, so that we have retries and polling and all
that goodness.  This patch contains two pieces of that:

Groovy scripts to implement the execution part of the pipeline
job.

Changes to the previously written Python-based checks, to make
them work under Python2 and to fix some poor design choices
around arguments and output that I had made when telling Jeff
the API for the first implementation.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>