### PR TITLE
uploadutils.py: use input() instead of raw_input() for Python3

### DIFF
--- a/dist/uploadutils.py
+++ b/dist/uploadutils.py
@@ -49,7 +49,7 @@ def __compute_hashes(filename):
 
 
 def __query_yes_no(question, default="yes"):
-    """Ask a yes/no question via raw_input() and return their answer.
+    """Ask a yes/no question via input() and return their answer.
 
     "question" is a string that is presented to the user.
     "default" is the presumed answer if the user just hits <Enter>.
@@ -71,7 +71,7 @@ def __query_yes_no(question, default="yes"):
 
     while True:
         sys.stdout.write(question + prompt)
-        choice = raw_input().lower()
+        choice = input().lower()
         if default is not None and choice == '':
             return valid[default]
         elif choice in valid:


### PR DESCRIPTION
Fixes this error during upload:
Continue? [y/N] Traceback (most recent call last):
  File "ompi-scripts/dist/upload-release-to-s3.py", line 132, in <module>
    uploadutils.upload_files(s3_client, bucket_name, key_prefix,
  File "/home/bgoglin/ompi-scripts/dist/uploadutils.py", line 228, in upload_files
    if not __query_yes_no('Continue?', 'no'):
  File "/home/bgoglin/ompi-scripts/dist/uploadutils.py", line 74, in __query_yes_no
    choice = raw_input().lower()
NameError: name 'raw_input' is not defined

Signed-off-by: Brice Goglin <Brice.Goglin@inria.fr>