### PR TITLE
Builder.py: fix Coverity submission Python error

### DIFF
--- a/nightly-tarball/Builder.py
+++ b/nightly-tarball/Builder.py
@@ -277,7 +277,7 @@ class Builder(object):
                         Coverity.run_coverity(self._logger,
                                               self._current_build['build_root'],
                                               os.path.join(self._current_build['source_tree'],
-                                                           self._current_build['artifacts'].keys()[0]),
+                                                           next(iter(self._current_build['artifacts'].keys()))),
                                               self._config['coverity'])
                     except Exception as e:
                         self._logger.error("ERROR: Coverity submission failed: %s"


### PR DESCRIPTION
dict.keys() returns a dict_keys object, which is not subscritable.
Hence, if "foo" is a dict, foo.keys()[0] is a Python error.  This led
to this error occurring in the OMPI nightly builds:

```
ERROR: Coverity submission failed: 'dict_keys' object is not subscriptable
```

Instead, convert the returned dict_keys to an iterator and grab the
first item via next().

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>