### PR TITLE
Coverity.py: remove kruft

### DIFF
--- a/nightly-tarball/Coverity.py
+++ b/nightly-tarball/Coverity.py
@@ -14,7 +14,6 @@ import logging
 import time
 import shlex
 import shutil
-import urllib
 import requests
 import BuilderUtils
 


### PR DESCRIPTION
No longer need the import urllib.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>