### PR TITLE
Number of Jenkins changes

### DIFF
--- a/jenkins/autotools-patches/m4-1.4.16.patch
+++ b/jenkins/autotools-patches/m4-1.4.16.patch
@@ -1,0 +1,113 @@
+diff --color -urp m4-1.4.16.orig/lib/fflush.c m4-1.4.16/lib/fflush.c
+--- m4-1.4.16.orig/lib/fflush.c	2011-03-01 16:39:27.000000000 +0000
++++ m4-1.4.16/lib/fflush.c	2021-09-11 19:37:54.112227455 +0000
+@@ -31,7 +31,7 @@
+ #undef fflush
+ 
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+ 
+ /* Clear the stream's ungetc buffer, preserving the value of ftello (fp).  */
+ static inline void
+@@ -138,7 +138,7 @@ rpl_fflush (FILE *stream)
+   if (stream == NULL || ! freading (stream))
+     return fflush (stream);
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+ 
+   clear_ungetc_buffer_preserving_position (stream);
+ 
+diff --color -urp m4-1.4.16.orig/lib/fpurge.c m4-1.4.16/lib/fpurge.c
+--- m4-1.4.16.orig/lib/fpurge.c	2011-03-01 16:39:27.000000000 +0000
++++ m4-1.4.16/lib/fpurge.c	2021-09-11 19:37:54.112227455 +0000
+@@ -61,7 +61,7 @@ fpurge (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-# if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++# if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   fp->_IO_read_end = fp->_IO_read_ptr;
+   fp->_IO_write_ptr = fp->_IO_write_base;
+   /* Avoid memory leak when there is an active ungetc buffer.  */
+diff --color -urp m4-1.4.16.orig/lib/freadahead.c m4-1.4.16/lib/freadahead.c
+--- m4-1.4.16.orig/lib/freadahead.c	2011-03-01 16:39:27.000000000 +0000
++++ m4-1.4.16/lib/freadahead.c	2021-09-11 19:37:54.112227455 +0000
+@@ -25,7 +25,7 @@
+ size_t
+ freadahead (FILE *fp)
+ {
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_write_ptr > fp->_IO_write_base)
+     return 0;
+   return (fp->_IO_read_end - fp->_IO_read_ptr)
+diff --color -urp m4-1.4.16.orig/lib/freading.c m4-1.4.16/lib/freading.c
+--- m4-1.4.16.orig/lib/freading.c	2011-03-01 16:39:27.000000000 +0000
++++ m4-1.4.16/lib/freading.c	2021-09-11 19:37:54.112227455 +0000
+@@ -31,7 +31,7 @@ freading (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-# if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++# if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   return ((fp->_flags & _IO_NO_WRITES) != 0
+           || ((fp->_flags & (_IO_NO_READS | _IO_CURRENTLY_PUTTING)) == 0
+               && fp->_IO_read_base != NULL));
+diff --color -urp m4-1.4.16.orig/lib/fseeko.c m4-1.4.16/lib/fseeko.c
+--- m4-1.4.16.orig/lib/fseeko.c	2011-03-01 16:39:28.000000000 +0000
++++ m4-1.4.16/lib/fseeko.c	2021-09-11 19:37:54.112227455 +0000
+@@ -40,7 +40,7 @@ fseeko (FILE *fp, off_t offset, int when
+ #endif
+ 
+   /* These tests are based on fpurge.c.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_read_end == fp->_IO_read_ptr
+       && fp->_IO_write_ptr == fp->_IO_write_base
+       && fp->_IO_save_base == NULL)
+@@ -106,7 +106,7 @@ fseeko (FILE *fp, off_t offset, int when
+           return -1;
+         }
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+       fp->_flags &= ~_IO_EOF_SEEN;
+ #elif defined __sferror || defined __DragonFly__ /* FreeBSD, NetBSD, OpenBSD, DragonFly, MacOS X, Cygwin */
+ # if defined __CYGWIN__
+diff --color -urp m4-1.4.16.orig/lib/stdio-impl.h m4-1.4.16/lib/stdio-impl.h
+--- m4-1.4.16.orig/lib/stdio-impl.h	2011-03-01 16:39:29.000000000 +0000
++++ m4-1.4.16/lib/stdio-impl.h	2021-09-11 19:37:54.112227455 +0000
+@@ -18,6 +18,12 @@
+    the same implementation of stdio extension API, except that some fields
+    have different naming conventions, or their access requires some casts.  */
+ 
++/* Glibc 2.28 made _IO_IN_BACKUP private.  For now, work around this
++   problem by defining it ourselves.  FIXME: Do not rely on glibc
++   internals.  */
++#if !defined _IO_IN_BACKUP && defined _IO_EOF_SEEN
++# define _IO_IN_BACKUP 0x100
++#endif
+ 
+ /* BSD stdio derived implementations.  */
+ 
+Only in m4-1.4.16/lib: stdio.h.~1~
+diff --color -urp m4-1.4.16.orig/lib/stdio.in.h m4-1.4.16/lib/stdio.in.h
+--- m4-1.4.16.orig/lib/stdio.in.h	2011-03-01 16:39:29.000000000 +0000
++++ m4-1.4.16/lib/stdio.in.h	2021-09-11 19:55:34.246406982 +0000
+@@ -158,11 +158,13 @@ _GL_WARN_ON_USE (fflush, "fflush is not
+                  "use gnulib module fflush for portable POSIX compliance");
+ #endif
+ 
++#if 0
+ /* It is very rare that the developer ever has full control of stdin,
+    so any use of gets warrants an unconditional warning.  Assume it is
+    always declared, since it is required by C89.  */
+ #undef gets
+ _GL_WARN_ON_USE (gets, "gets is a security hole - use fgets instead");
++#endif
+ 
+ #if @GNULIB_FOPEN@
+ # if @REPLACE_FOPEN@
+Only in m4-1.4.16/lib: stdio.in.h.~1~

--- a/jenkins/autotools-patches/m4-1.4.17.patch
+++ b/jenkins/autotools-patches/m4-1.4.17.patch
@@ -1,0 +1,103 @@
+diff --color -urp m4-1.4.17.orig/lib/fflush.c m4-1.4.17/lib/fflush.c
+--- m4-1.4.17.orig/lib/fflush.c	2013-09-22 06:15:20.000000000 +0000
++++ m4-1.4.17/lib/fflush.c	2021-09-11 03:50:41.125878146 +0000
+@@ -33,7 +33,7 @@
+ #undef fflush
+ 
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+ 
+ /* Clear the stream's ungetc buffer, preserving the value of ftello (fp).  */
+ static void
+@@ -71,7 +71,7 @@ clear_ungetc_buffer (FILE *fp)
+ 
+ #endif
+ 
+-#if ! (defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */)
++#if ! (defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */)
+ 
+ # if (defined __sferror || defined __DragonFly__) && defined __SNPT /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin */
+ 
+@@ -145,7 +145,7 @@ rpl_fflush (FILE *stream)
+   if (stream == NULL || ! freading (stream))
+     return fflush (stream);
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+ 
+   clear_ungetc_buffer_preserving_position (stream);
+ 
+diff --color -urp m4-1.4.17.orig/lib/fpurge.c m4-1.4.17/lib/fpurge.c
+--- m4-1.4.17.orig/lib/fpurge.c	2013-09-22 06:15:20.000000000 +0000
++++ m4-1.4.17/lib/fpurge.c	2021-09-11 03:50:41.125878146 +0000
+@@ -61,7 +61,7 @@ fpurge (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-# if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++# if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   fp->_IO_read_end = fp->_IO_read_ptr;
+   fp->_IO_write_ptr = fp->_IO_write_base;
+   /* Avoid memory leak when there is an active ungetc buffer.  */
+diff --color -urp m4-1.4.17.orig/lib/freadahead.c m4-1.4.17/lib/freadahead.c
+--- m4-1.4.17.orig/lib/freadahead.c	2013-09-22 06:15:20.000000000 +0000
++++ m4-1.4.17/lib/freadahead.c	2021-09-11 03:50:41.125878146 +0000
+@@ -25,7 +25,7 @@
+ size_t
+ freadahead (FILE *fp)
+ {
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_write_ptr > fp->_IO_write_base)
+     return 0;
+   return (fp->_IO_read_end - fp->_IO_read_ptr)
+diff --color -urp m4-1.4.17.orig/lib/freading.c m4-1.4.17/lib/freading.c
+--- m4-1.4.17.orig/lib/freading.c	2013-09-22 06:15:20.000000000 +0000
++++ m4-1.4.17/lib/freading.c	2021-09-11 03:50:41.125878146 +0000
+@@ -31,7 +31,7 @@ freading (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-# if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++# if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   return ((fp->_flags & _IO_NO_WRITES) != 0
+           || ((fp->_flags & (_IO_NO_READS | _IO_CURRENTLY_PUTTING)) == 0
+               && fp->_IO_read_base != NULL));
+diff --color -urp m4-1.4.17.orig/lib/fseeko.c m4-1.4.17/lib/fseeko.c
+--- m4-1.4.17.orig/lib/fseeko.c	2013-09-22 06:15:55.000000000 +0000
++++ m4-1.4.17/lib/fseeko.c	2021-09-11 03:50:41.125878146 +0000
+@@ -47,7 +47,7 @@ fseeko (FILE *fp, off_t offset, int when
+ #endif
+ 
+   /* These tests are based on fpurge.c.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_read_end == fp->_IO_read_ptr
+       && fp->_IO_write_ptr == fp->_IO_write_base
+       && fp->_IO_save_base == NULL)
+@@ -121,7 +121,7 @@ fseeko (FILE *fp, off_t offset, int when
+           return -1;
+         }
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+       fp->_flags &= ~_IO_EOF_SEEN;
+       fp->_offset = pos;
+ #elif defined __sferror || defined __DragonFly__ /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin */
+diff --color -urp m4-1.4.17.orig/lib/stdio-impl.h m4-1.4.17/lib/stdio-impl.h
+--- m4-1.4.17.orig/lib/stdio-impl.h	2013-09-22 06:20:02.000000000 +0000
++++ m4-1.4.17/lib/stdio-impl.h	2021-09-11 03:50:41.125878146 +0000
+@@ -18,6 +18,12 @@
+    the same implementation of stdio extension API, except that some fields
+    have different naming conventions, or their access requires some casts.  */
+ 
++/* Glibc 2.28 made _IO_IN_BACKUP private.  For now, work around this
++   problem by defining it ourselves.  FIXME: Do not rely on glibc
++   internals.  */
++#if !defined _IO_IN_BACKUP && defined _IO_EOF_SEEN
++# define _IO_IN_BACKUP 0x100
++#endif
+ 
+ /* BSD stdio derived implementations.  */
+ 

--- a/jenkins/autotools-patches/m4-1.4.18.patch
+++ b/jenkins/autotools-patches/m4-1.4.18.patch
@@ -1,0 +1,115 @@
+diff --color -urp m4-1.4.18.orig/lib/fflush.c m4-1.4.18/lib/fflush.c
+--- m4-1.4.18.orig/lib/fflush.c	2016-12-31 13:54:41.000000000 +0000
++++ m4-1.4.18/lib/fflush.c	2021-09-11 03:47:08.623555635 +0000
+@@ -33,7 +33,7 @@
+ #undef fflush
+ 
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+ 
+ /* Clear the stream's ungetc buffer, preserving the value of ftello (fp).  */
+ static void
+@@ -72,7 +72,7 @@ clear_ungetc_buffer (FILE *fp)
+ 
+ #endif
+ 
+-#if ! (defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */)
++#if ! (defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */)
+ 
+ # if (defined __sferror || defined __DragonFly__ || defined __ANDROID__) && defined __SNPT
+ /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Android */
+@@ -148,7 +148,7 @@ rpl_fflush (FILE *stream)
+   if (stream == NULL || ! freading (stream))
+     return fflush (stream);
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+ 
+   clear_ungetc_buffer_preserving_position (stream);
+ 
+diff --color -urp m4-1.4.18.orig/lib/fpending.c m4-1.4.18/lib/fpending.c
+--- m4-1.4.18.orig/lib/fpending.c	2016-12-31 13:54:41.000000000 +0000
++++ m4-1.4.18/lib/fpending.c	2021-09-11 03:47:08.623555635 +0000
+@@ -32,7 +32,7 @@ __fpending (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   return fp->_IO_write_ptr - fp->_IO_write_base;
+ #elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
+   /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Android */
+diff --color -urp m4-1.4.18.orig/lib/fpurge.c m4-1.4.18/lib/fpurge.c
+--- m4-1.4.18.orig/lib/fpurge.c	2016-12-31 13:54:41.000000000 +0000
++++ m4-1.4.18/lib/fpurge.c	2021-09-11 03:47:08.623555635 +0000
+@@ -62,7 +62,7 @@ fpurge (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-# if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++# if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   fp->_IO_read_end = fp->_IO_read_ptr;
+   fp->_IO_write_ptr = fp->_IO_write_base;
+   /* Avoid memory leak when there is an active ungetc buffer.  */
+diff --color -urp m4-1.4.18.orig/lib/freadahead.c m4-1.4.18/lib/freadahead.c
+--- m4-1.4.18.orig/lib/freadahead.c	2016-12-31 13:54:41.000000000 +0000
++++ m4-1.4.18/lib/freadahead.c	2021-09-11 03:47:08.623555635 +0000
+@@ -25,7 +25,7 @@
+ size_t
+ freadahead (FILE *fp)
+ {
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_write_ptr > fp->_IO_write_base)
+     return 0;
+   return (fp->_IO_read_end - fp->_IO_read_ptr)
+diff --color -urp m4-1.4.18.orig/lib/freading.c m4-1.4.18/lib/freading.c
+--- m4-1.4.18.orig/lib/freading.c	2016-12-31 13:54:41.000000000 +0000
++++ m4-1.4.18/lib/freading.c	2021-09-11 03:47:08.623555635 +0000
+@@ -31,7 +31,7 @@ freading (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-# if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++# if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   return ((fp->_flags & _IO_NO_WRITES) != 0
+           || ((fp->_flags & (_IO_NO_READS | _IO_CURRENTLY_PUTTING)) == 0
+               && fp->_IO_read_base != NULL));
+diff --color -urp m4-1.4.18.orig/lib/fseeko.c m4-1.4.18/lib/fseeko.c
+--- m4-1.4.18.orig/lib/fseeko.c	2016-12-31 13:54:41.000000000 +0000
++++ m4-1.4.18/lib/fseeko.c	2021-09-11 03:47:08.623555635 +0000
+@@ -47,7 +47,7 @@ fseeko (FILE *fp, off_t offset, int when
+ #endif
+ 
+   /* These tests are based on fpurge.c.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_read_end == fp->_IO_read_ptr
+       && fp->_IO_write_ptr == fp->_IO_write_base
+       && fp->_IO_save_base == NULL)
+@@ -123,7 +123,7 @@ fseeko (FILE *fp, off_t offset, int when
+           return -1;
+         }
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+       fp->_flags &= ~_IO_EOF_SEEN;
+       fp->_offset = pos;
+ #elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
+diff --color -urp m4-1.4.18.orig/lib/stdio-impl.h m4-1.4.18/lib/stdio-impl.h
+--- m4-1.4.18.orig/lib/stdio-impl.h	2016-12-31 13:54:42.000000000 +0000
++++ m4-1.4.18/lib/stdio-impl.h	2021-09-11 03:47:08.623555635 +0000
+@@ -18,6 +18,12 @@
+    the same implementation of stdio extension API, except that some fields
+    have different naming conventions, or their access requires some casts.  */
+ 
++/* Glibc 2.28 made _IO_IN_BACKUP private.  For now, work around this
++   problem by defining it ourselves.  FIXME: Do not rely on glibc
++   internals.  */
++#if !defined _IO_IN_BACKUP && defined _IO_EOF_SEEN
++# define _IO_IN_BACKUP 0x100
++#endif
+ 
+ /* BSD stdio derived implementations.  */
+ 

--- a/jenkins/open-mpi-autotools-build.sh
+++ b/jenkins/open-mpi-autotools-build.sh
@@ -1,39 +1,170 @@
 #!/bin/bash
 #
 # Install (building if necessary) the autotools packages necessary for
-# building a particular version of Open MPI.
+# building a particular package.
 #
 # We build and save artifacts outside of the Jenkins workspace, which
 # is a little odd, but allows us to persist builds across jobs (and
-# avoid any job-specific naming problems in paths).  We will write the
-# autotools installations into $HOME/autotools-setup/ unless otherwise
-# instructed.  If JENKINS_AGENT_HOME is set, we will use that instead
-# of $HOME.
+# avoid any job-specific naming problems in paths).
 #
 # In addition to building and saving artifacts (including to S3 for
 # EC2 instances), this script can be called for every job to create a
-# simlink from the built autotools into $WORKSPACE/autotools-install.
+# simlink from the built autotools into <target>
 #
-# usage: ./open-mpi-autotools-build.sh <ompi tree>
-#
+# usage: ./open-mpi-autotools-build.sh
+#            [-z <dist_script_for_versions]
+#            [-r <autotools_root>
+#            [-c <autoconf_version] [-m <automake version]
+#            [-l <libtool_version] [-n <m4 version>]
+#            [-f <flex_version>]
 
-# be lazy...
-set -e
+dist_script=
+debug=0
+autotools_root=
+target_link=
+dist_script_path="/dev/null"
+patch_file_directory=
+s3_build_path="s3://ompi-jenkins-config/autotools-builds"
+autotools_scratch_dir=
 
-ompi_tree=$1
-dist_script=${ompi_tree}/contrib/dist/make_dist_tarball
-s3_path="s3://ompi-jenkins-config/autotools-builds"
+usage() {
+     echo "Usage: $0 -r <DIR> -t <LINK> [OPTION]..."
+     echo "Build autotools necessary for OMPI-related project builds"
+     echo ""
+     echo "Mandatory Arguments:"
+     echo "  -r DIR      Leave build artifacts in DIR and use DIR for building"
+     echo "              temporary artifacts.  On non-ephemeral instances, DIR"
+     echo "              should be outside of a Jenkins workspace to avoid"
+     echo "              unnecessary rebuilding of autotools."
+     echo "  -t LINK     Create symlnk LINK to the autotools build requested."
+     echo "              Unlike -r, this option frequently is in a Jenkins"
+     echo "              workspace, as it is ephemeral to a build."
+     echo ""
+     echo "Optional Arguments"
+     echo "  -d          If specified, enable debug output."
+     echo "  -p DIR      Directory to search for patch files.  If a patch file"
+     echo "              named <package_name>-<version>.patch is found in DIR"
+     echo "              it will be applied to <package_name> before building."
+     echo "  -z FILE     Pull required Autotools versions from an Open MPI like"
+     echo "              dist script.  This option assumes certain variables are"
+     echo "              set in FILE.  This option is exclusive with -c, -m, -l,"
+     echo "              -n, and -f options."
+     echo "  -{c,m,l,n,f} VERSION  Use VERSION as the required version string for"
+     echo "              Autoconf, Automake, Libtool, M4, and Flex (respectively)."
+     echo "              If one of these arguments is set, all must be set.  Either"
+     echo "              these arguments or -z must be specified."
+     echo "  -h          Print this usage message and exit."
+}
 
-if test ! -n "${JENKINS_AGENT_HOME}" ; then
-    JENKINS_AGENT_HOME=${HOME}
-fi
-autotools_root=${JENKINS_AGENT_HOME}/autotools-builds
-mkdir -p "${autotools_root}"
+debug_print() {
+    if [[ $debug -ne 0 ]] ; then
+        echo $1
+    fi
+}
 
-if test ! -r ${dist_script} ; then
-    echo "Can not read ${dist_script}.  Aborting."
+clean_scratch_dir() {
+    if [[ -n "$autotools_scratch_dir" ]] ; then
+        echo "cleaning $autotools_scratch_dir"
+        rm -rf "$autotools_scratch_dir"
+    fi
+}
+
+if [[ $# -eq 0 ]]; then
+    usage
     exit 1
 fi
+while getopts ":dz:r:t:c:m:l:n:f:p:h" arg; do
+    case $arg in
+        d)
+            debug=1
+            ;;
+        p)
+            patch_file_directory=${OPTARG}
+            patch_file_directory=`realpath ${patch_file_directory}`
+            ;;
+        r)
+            autotools_root=${OPTARG}
+            ;;
+        t)
+            target_link=${OPTARG}
+            ;;
+        z)
+            dist_script=${OPTARG}
+            ;;
+        c)
+            AC_VERSION=${OPTARG}
+            ;;
+        m)
+            AM_VERSION=${OPTARG}
+            ;;
+        l)
+            LT_VERSION=${OPTARG}
+            ;;
+        n)
+            M4_VERSION=${OPTARG}
+            ;;
+        f)
+            FLEX_VERSION=${OPTARG}
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+# command line checking
+if [[ -z "${target_link}" ]] ; then
+    echo "-t <target_link> is a required option, but is not set."
+    exit 1
+fi
+if [[ -z "${autotools_root}" ]] ; then
+    echo "-r <build root> is a required option, but is not set."
+    exit 1
+fi
+
+trap clean_scratch_dir EXIT
+
+mkdir -p "${autotools_root}"
+if [[ $? -ne 0 ]] ; then
+     echo "Could not create directory ${autotools_root}.  Cannot continue."
+     exit 2
+fi
+
+# If a dist script was specified, grab the version files from there.
+# Otherwise, expect all the versions to be explicitly specified.
+if [[ -n "${dist_script}" ]] ; then
+    debug_print "Finding versions from dist script ${dist_script}"
+    if [[ ! -r ${dist_script} ]] ; then
+        echo "Cannot read ${dist_script}.  Aborting."
+        exit 1
+    fi
+
+    for pkg in AC AM LT M4 FLEX ; do
+        eval "${pkg}_VERSION=`sed -ne \"s/^${pkg}_TARGET_VERSION=\(.*\)/\1/p\" ${dist_script}`"
+	eval "var=${pkg}_VERSION"
+	if test -z "${var}" ; then
+            echo "${pkg_VERSION} not set in ${dist_script}"
+            exit 2
+        fi
+    done
+else
+    for pkg in AC AM LT M4 FLEX ; do
+        eval "var=\"\$${pkg}_VERSION\""
+        if test -z "${var}" ; then
+            echo "${pkg}_VERSION not set on command line"
+            exit 1
+        fi
+    done
+fi
+for pkg in AC AM LT M4 FLEX ; do
+    eval "var=\"\$${pkg}_VERSION\""
+    debug_print "${pkg}_VERSION: $var"
+done
 
 os=`uname -s`
 if test "${os}" = "Linux"; then
@@ -45,61 +176,95 @@ else
 fi
 
 if `echo ${NODE_NAME} | grep -q '^EC2'` ; then
-    IS_EC2="yes"
+    IS_EC2_JENKINS="yes"
 else
-    IS_EC2="no"
+    IS_EC2_JENKINS="no"
 fi
 
-echo "==> Platform: $PLATFORM_ID"
-echo "==> Version:  $VERSION_ID"
-echo "==> EC2: $IS_EC2"
-
-for pkg in AC AM LT M4 FLEX; do
-    eval "${pkg}_VERSION=`sed -ne \"s/^${pkg}_TARGET_VERSION=\(.*\)/\1/p\" ${dist_script}`"
-done
+debug_print "Platform: $PLATFORM_ID"
+debug_print "Version:  $VERSION_ID"
+debug_print "EC2 Jenkins Worker: $IS_EC2_JENKINS"
 
 version_string="${AC_VERSION}-${AM_VERSION}-${LT_VERSION}-${M4_VERSION}-${FLEX_VERSION}"
 tarball_name="autotools-${PLATFORM_ID}_${VERSION_ID}-${version_string}.tar.gz"
 autotools_install_short="autotools-install-${version_string}"
 autotools_install="${autotools_root}/${autotools_install_short}"
-echo "==> Version string: ${version_string}"
+debug_print "Version string: ${version_string}"
 
 cd ${autotools_root}
 
-if test ${IS_EC2} = "yes" && test ! -d ${autotools_install} ; then
-    if aws s3 cp ${s3_path}/${tarball_name} . >& /dev/null ; then
-        echo "==> Downloaded build from S3"
+if [[ ${IS_EC2_JENKINS} = "yes" && ! -d ${autotools_install} ]] ; then
+    debug_print "Attempting to download cached build ${s3_build_path}/${tarball_name}"
+    if aws s3 cp ${s3_build_path}/${tarball_name} . >& /dev/null ; then
+        debug_print "Downloaded build from S3"
         tar xf ${tarball_name}
         rm ${tarball_name}
     fi
 fi
 
-if test ! -d ${autotools_install} ; then
-    echo "==> No build found ; building from scratch"
+if [[ ! -d ${autotools_install} ]] ; then
+    debug_print "==> No build found ; building from scratch"
 
-    autotools_srcdir="${autotools_root}/autotools-src.$$"
-
-    mkdir -p ${autotools_srcdir}
-    cd ${autotools_srcdir}
+    autotools_scratch_dir=$(mktemp -d ${autotools_root}/autotools-src.XXXXXXXX)
+    cd ${autotools_scratch_dir}
+    debug_print "build dir: $autotools_scratch_dir"
 
     export PATH=${autotools_install/bin}:${PATH}
     export LD_LIBRARY_PATH=${autotools_install}/lib:${LD_LIBRARY_PATH}
 
-    curl -fO http://ftp.gnu.org/gnu/autoconf/autoconf-${AC_VERSION}.tar.gz
+    build_cleanup() {
+        echo "Building autotools failed.  Cleaning ${autotools_install}."
+        if [[ -d "${autotools_install}" ]] ; then
+            rm -rf "${autotools_install}"
+        fi
+        exit 5
+    }
+    trap build_cleanup ERR
+
+    # TODO: Error checking!
+    curl -fLO http://ftp.gnu.org/gnu/m4/m4-${M4_VERSION}.tar.gz
+    tar xf m4-${M4_VERSION}.tar.gz
+    patch_file="${patch_file_directory}/m4-${M4_VERSION}.patch"
+    if [[ -r ${patch_file} ]] ; then
+        debug_print "Appying patch m4-${M4_VERSION}.patch"
+        (cd m4-${M4_VERSION} ; patch -p 1 < ${patch_file})
+    else
+        debug_print "patch m4-${M4_VERSION}.patch not found."
+    fi
+    (cd m4-${M4_VERSION} ; ./configure --prefix=${autotools_install} ; make install)
+
+    curl -fLO http://ftp.gnu.org/gnu/autoconf/autoconf-${AC_VERSION}.tar.gz
     tar xf autoconf-${AC_VERSION}.tar.gz
+    patch_file="${patch_file_directory}/autoconf-${AC_VERSION}.patch"
+    if [[ -r ${patch_file} ]] ; then
+        debug_print "Appying patch autoconf-${AC_VERSION}.patch"
+        (cd autoconf-${AC_VERSION} ; patch -p 1 < ${patch_file})
+    else
+        debug_print "patch autoconf-${AC_VERSION}.patch not found."
+    fi
     (cd autoconf-${AC_VERSION} ; ./configure --prefix=${autotools_install} ; make install)
 
-    curl -fO http://ftp.gnu.org/gnu/automake/automake-${AM_VERSION}.tar.gz
+    curl -fLO http://ftp.gnu.org/gnu/automake/automake-${AM_VERSION}.tar.gz
     tar xf automake-${AM_VERSION}.tar.gz
+    patch_file="${patch_file_directory}/automake-${AM_VERSION}.patch"
+    if [[ -r ${patch_file} ]] ; then
+        debug_print "Appying patch automake-${AM_VERSION}.patch"
+        (cd automake-${AM_VERSION} ; patch -p 1 < ${patch_file})
+    else
+        debug_print "patch automake-${AM_VERSION}.patch not found."
+    fi
     (cd automake-${AM_VERSION} ; ./configure --prefix=${autotools_install} ; make install)
 
-    curl -fO http://ftp.gnu.org/gnu/libtool/libtool-${LT_VERSION}.tar.gz
+    curl -fLO http://ftp.gnu.org/gnu/libtool/libtool-${LT_VERSION}.tar.gz
     tar xf libtool-${LT_VERSION}.tar.gz
+    patch_file="${patch_file_directory}/libtool-${LT_VERSION}.patch"
+    if [[ -r ${patch_file} ]] ; then
+        debug_print "Appying patch libtool-${LT_VERSION}.patch"
+        (cd libtool-${LT_VERSION} ; patch -p 1 < ${patch_file})
+    else
+        debug_print "patch libtool-${LT_VERSION}.patch not found."
+    fi
     (cd libtool-${LT_VERSION} ; ./configure --prefix=${autotools_install} ; make install)
-
-    curl -fO http://ftp.gnu.org/gnu/m4/m4-${M4_VERSION}.tar.gz
-    tar xf m4-${M4_VERSION}.tar.gz
-    (cd m4-${M4_VERSION} ; ./configure --prefix=${autotools_install} ; make install)
 
     # When flex moved from ftp.gnu.org to sourceforge to GitHub for
     # downloads, they dropped all the archive versions.  Including the
@@ -107,25 +272,36 @@ if test ! -d ${autotools_install} ; then
     # (stolen from a distro archive repository) for use.  Hopefully,
     # one day, we will be able to update :).
     flex_tarball="flex-${FLEX_VERSION}.tar.gz"
-    if ! curl -fO https://github.com/westes/flex/releases/download/v${FLEX_VERSION}/${flex_tarball}  ; then
-        curl -fO https://download.open-mpi.org/archive/flex/${flex_tarball}
+    if ! curl -fLO https://github.com/westes/flex/releases/download/v${FLEX_VERSION}/${flex_tarball}  ; then
+        curl -fLO https://download.open-mpi.org/archive/flex/${flex_tarball}
     fi
     tar xf ${flex_tarball}
+    patch_file="${patch_file_directory}/flex-${FLEX_VERSION}.patch"
+    if [[ -r ${patch_file} ]] ; then
+        debug_print "Appying patch flex-${FLEX_VERSION}.patch"
+        (cd flex-${FLEX_VERSION} ; patch -p 1 < ${patch_file})
+    else
+        debug_print "patch flex-${FLEX_VERSION}.patch not found."
+    fi
     (cd flex-${FLEX_VERSION} ; ./configure --prefix=${autotools_install} ; make install)
+
+    trap - ERR
 
     cd  ${autotools_root}
 
-    # autotools_srcdir was unique to this process, so this is safe
-    # even in a concurrent Jenkins jobs situation.
-    rm -rf ${autotools_srcdir}
-
-    if test "$IS_EC2" = "yes" ; then
+    if test "$IS_EC2_JENKINS" = "yes" ; then
         echo "==> Archiving build to S3"
-        tar czf ${tarball_name} ${autotools_install_short}
-        aws s3 cp ${tarball_name} ${s3_path}/${tarball_name}
-        rm ${tarball_name}
+        tar czf "${tarball_name}" "${autotools_install_short}"
+        aws s3 cp "${tarball_name}" "${s3_build_path}/${tarball_name}"
+        rm "${tarball_name}"
     fi
 fi
 
-echo "==> Symlinking ${autotools_install} to ${WORKSPACE}/autotools-install"
-ln -s ${autotools_install} ${WORKSPACE}/autotools-install
+if [[ -e "${target_link}" && ! -L "${target_link}" ]] ; then
+    echo "${target_link} exists but is not a symlink.  Cowardly not creating link."
+    exit 99
+else
+    echo "==> Symlinking ${autotools_install} to ${target_link}"
+    rm -f "${target_link}"
+    ln -s "${autotools_install}" "${target_link}"
+fi

--- a/jenkins/open-mpi.dist.create-tarball.groovy
+++ b/jenkins/open-mpi.dist.create-tarball.groovy
@@ -178,8 +178,11 @@ def checkout_code() {
 		 doGenerateSubmoduleConfigurations: false,
 		 extensions: [[$class: 'WipeWorkspace'],
 			      [$class: 'RelativeTargetDirectory',
-			       relativeTargetDir: 'ompi']],
-		 submoduleCfg: [],
+			       relativeTargetDir: 'ompi'],
+                              [$class: 'SubmoduleOption',
+                               recursiveSubmodules: 'true',
+                               disableSubmodules: 'false',
+                               parentCredentials: 'true']],
 		 userRemoteConfigs: [[credentialsId: '6de58bf1-2619-4065-99bb-8d284b4691ce',
 				      url: 'https://github.com/open-mpi/ompi/']]])
   // scm is a provided global variable that points to the repository

--- a/jenkins/open-mpi.dist.create-tarball.groovy
+++ b/jenkins/open-mpi.dist.create-tarball.groovy
@@ -37,11 +37,17 @@ node(rpm_builder) {
   }
 
   stage('Installing Dependencies') {
-    // because we build tags or hashes, not just branch heads,
-    // there's not a great way to do the branch -> Autotools
-    // version matching.  So instead grab them from the
-    // make_dist_tarball script
-    sh '/bin/bash ompi-scripts/jenkins/open-mpi-autotools-build.sh ompi'
+    // Build Autotools based on the dist script found in the active build
+    // branch.
+
+    // The tarball builder jobs only ever run on EC2 instances, so it
+    // should always be safe to use $HOME as the location for autotools
+    // build artifacts, as the EC2 instances always have a dedicated
+    // Jenkins user.  If you are copying this code for another job (like
+    // a CI test), please be careful about writing into $HOME.  The Cray
+    // builders in particular are using shared accounts.
+
+    sh "/bin/bash ompi-scripts/jenkins/open-mpi-autotools-build.sh -d -p ompi-scripts/jenkins/autotools-patches -t ${WORKSPACE}/autotools-install -r ${env.HOME}/autotools-builds -z ${WORKSPACE}/ompi/contrib/dist/make_dist_tarball"
   }
 
   // Build the initial tarball, verify that the resulting tarball

--- a/jenkins/packer.json
+++ b/jenkins/packer.json
@@ -286,37 +286,6 @@
     "iam_instance_profile" : "{{user `iam_role`}}"
   },{
     "type": "amazon-ebs",
-    "name" : "SLES12-x86",
-    "ami_name": "Jenkins SLES 12 x86_64 {{user `build_date`}}",
-    "region": "us-west-2",
-    "source_ami_filter": {
-        "filters": {
-            "architecture": "x86_64",
-            "virtualization-type": "hvm",
-            "root-device-type": "ebs",
-            "name": "suse-sles-12-*"
-        },
-        "owners": ["amazon"],
-        "most_recent": true
-    },
-    "ami_block_device_mappings": [ {
-        "device_name": "/dev/sda1",
-        "volume_size": 16,
-        "delete_on_termination": true
-        } ],
-    "launch_block_device_mappings": [ {
-        "device_name": "/dev/sda1",
-        "volume_size": 16,
-        "delete_on_termination": true
-    } ],
-    "instance_type": "t3.micro",
-    "ssh_username": "ec2-user",
-    "ssh_pty" : true,
-    "associate_public_ip_address" : true,
-    "ena_support" : true,
-    "iam_instance_profile" : "{{user `iam_role`}}"
-  },{
-    "type": "amazon-ebs",
     "name" : "SLES15-x86",
     "ami_name": "Jenkins SLES 15 x86_64 {{user `build_date`}}",
     "region": "us-west-2",
@@ -325,7 +294,7 @@
             "architecture": "x86_64",
             "virtualization-type": "hvm",
             "root-device-type": "ebs",
-            "name": "suse-sles-15-*"
+            "name": "suse-sles-15-sp??-v????????-hvm-ssd*"
         },
         "owners": ["amazon"],
         "most_recent": true


### PR DESCRIPTION
A bundle of Jenkins changes for your Sunday night.

1. Rework the autotools build script to be usable outside of the dist script (next stop is the nightly tarball builder)
2. Add patch files (and ability to apply patch files) for building older versions of M4 on Ubuntu 18.04 and 20.04
3. Support submodules in dist job (for 5.0 branch)
4. Update the script to build new AMIs to install pandoc everywhere.