### PR TITLE
Do a recursive clone by default.

### DIFF
--- a/nightly-tarball/Builder.py
+++ b/nightly-tarball/Builder.py
@@ -370,7 +370,7 @@ class Builder(object):
 
         # get an up-to-date git repository
         self._logger.debug("Cloning from " + remote_repository)
-        repo = Repo.clone_from(remote_repository, source_tree)
+        repo = Repo.clone_from(remote_repository, source_tree, recursive=True)
 
         # switch to the right branch and reset the HEAD to be
         # origin/<branch>/HEAD


### PR DESCRIPTION
This will allow master/v5.0 to clone correctly.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>