### PR TITLE
nightly: Support relative submodule paths

### DIFF
--- a/nightly-tarball/Builder.py
+++ b/nightly-tarball/Builder.py
@@ -376,12 +376,11 @@ class Builder(object):
         # origin/<branch>/HEAD
         self._logger.debug("Switching to branch: " + branch)
         if not branch in repo.heads:
-            # TODO: Can we avoid calling into repo.git here?
-            repo.git.checkout('origin/' + branch, b=branch)
-        repo.head.reference = repo.refs['origin/' + branch]
+            repo.git.checkout(branch)
+        repo.head.reference = repo.refs[branch]
 
         # And pull in all the right submodules
-        repo.submodule_update(recursive = True)
+        repo.git.submodule('update', '--init', '--recursive')
 
         # wish I could figure out how to do this without resorting to
         # shelling out to git :/


### PR DESCRIPTION
GitPython's internal submodules support is not a direct call to
the underlying git submodule interface, but does a bunch of
magic that we do not need.  It also does not support relative
paths, which are now used in OMPI's submodule definition.  Switch
to using the underlying git submodule calls directly to fetch
the submodules.

Using the underlying submodules command required us to have a HEAD
that is in refs/ as a local branch.  Change the checkout command
so that the branch we are building is a local branch to stop
irritating git submodule commands.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>