### PR TITLE
Allow building Sphinx docs

### DIFF
--- a/jenkins/open-mpi-build-script.sh
+++ b/jenkins/open-mpi-build-script.sh
@@ -179,6 +179,9 @@ fi
 # ./configure --help.  In prep for 5.0, we added a developer
 # requirement for pandoc to build (not required for dist tarballs),
 # with an explicit option to disable.
+# JMS: The requirement will shortly change from pandoc to Sphinx.
+# Keep pandoc for now; when Sphinx is brought to the v5.0.x branch, we
+# can delete this whole Pandoc-specific if/else block.
 if `which pandoc > /dev/null 2>&1` ; then
     echo "--> Found pandoc.  Allowing default manpage behavior"
 else


### PR DESCRIPTION
If docs/requirements.txt exists in the source tree, that means that we
have Sphinx documentation, not Pandoc documentation.  Create a Python
virtual environment before running configure and install the Right
things for Sphinx to build the man pages.  This also means that there
will be no Pandoc-generated man pages, so don't bother trying to
convert them to HTML.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>