### PR TITLE
open-mpi-build-script.sh: run singletons

### DIFF
--- a/jenkins/open-mpi-build-script.sh
+++ b/jenkins/open-mpi-build-script.sh
@@ -267,11 +267,13 @@ if test "${MPIRUN_MODE}" != "none"; then
 	    ;;
     esac
     run_example "${exec}" ./examples/hello_c
+    run_example ./examples/hello_c ""
     run_example "${exec}" ./examples/ring_c
     run_example "${exec}" ./examples/connectivity_c
     if ompi_info --parsable | grep -q bindings:cxx:yes >/dev/null; then
         echo "--> running C++ examples"
         run_example "${exec}" ./examples/hello_cxx
+        run_example ./examples/hello_cxx ""
         run_example "${exec}" ./examples/ring_cxx
     else
         echo "--> skipping C++ examples"
@@ -279,6 +281,7 @@ if test "${MPIRUN_MODE}" != "none"; then
     if ompi_info --parsable | grep -q bindings:mpif.h:yes >/dev/null; then
         echo "--> running mpif examples"
         run_example "${exec}" ./examples/hello_mpifh
+        run_example ./examples/hello_mpifh ""
         run_example "${exec}" ./examples/ring_mpifh
     else
         echo "--> skipping mpif examples"
@@ -286,6 +289,7 @@ if test "${MPIRUN_MODE}" != "none"; then
     if ompi_info --parsable | egrep -q bindings:use_mpi:\"\?yes >/dev/null; then
         echo "--> running usempi examples"
         run_example "${exec}" ./examples/hello_usempi
+        run_example ./examples/hello_usempi ""
         run_example "${exec}" ./examples/ring_usempi
     else
         echo "--> skipping usempi examples"
@@ -293,6 +297,7 @@ if test "${MPIRUN_MODE}" != "none"; then
     if ompi_info --parsable | grep -q bindings:use_mpi_f08:yes >/dev/null; then
         echo "--> running usempif08 examples"
         run_example "${exec}" ./examples/hello_usempif08
+        run_example ./examples/hello_usempif08 ""
         run_example "${exec}" ./examples/ring_usempif08
     else
         echo "--> skipping usempif08 examples"


### PR DESCRIPTION
Run the "hello" examples as singletons (just "./hello_c" with no
"mpirun").

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

----

@bwbarrett I figured this would add negligible time to the test, and would actually alert us when singletons break.