### PR TITLE
Fix Open MPI RPM build step: build and install deps

### DIFF
--- a/jenkins/open-mpi.dist.create-tarball.build-rpm.sh
+++ b/jenkins/open-mpi.dist.create-tarball.build-rpm.sh
@@ -18,27 +18,33 @@ aws s3 cp ${build_prefix}/${srpm_name} ${srpm_name}
 
 # Build and install PRRTE and OpenPMIX, if available
 if [[ -d ${WORKSPACE}/ompi/3rd-party/openpmix ]]; then
+    echo "Building OpenPMIx RPM"
     pushd ${WORKSPACE}/ompi/3rd-party/openpmix
     ./autogen.pl; ./configure; make dist
     cd contrib
     tarball=$(find .. -name "*.bz2" -print)
     rpmtopdir="${WORKSPACE}/rpmbuild" build_srpm=no build_single=yes ./buildrpm.sh $tarball
     rpm_name=$(find ${WORKSPACE}/rpmbuild/RPMS -name "pmix*.rpm" -print)
+    echo "Installing OpenPMIx RPM"
     sudo rpm -Uvh ${rpm_name}
     popd
 fi
 
 if [[ -d ${WORKSPACE}/ompi/3rd-party/prrte ]]; then
+    echo "Building PRRTE RPM"
     pushd ${WORKSPACE}/ompi/3rd-party/prrte
     ./autogen.pl; ./configure; make dist
     cd contrib/dist/linux
     tarball=$(find ../../.. -name "*.bz2" -print)
     rpmtopdir="${WORKSPACE}/rpmbuild" ./buildrpm.sh -b "${tarball}"
     rpm_name=$(find ${WORKSPACE}/rpmbuild/RPMS -name "prrte*.rpm" -print)
+    echo "Installing PRRTE RPM"
     sudo rpm -Uvh ${rpm_name}
     popd
 fi
 
+echo "Building Open MPI RPM"
 rpmbuild --rebuild ${srpm_name}
 bin_rpm_name=`find ${WORKSPACE}/rpmbuild/RPMS -name "openmpi*.rpm" -print`
+echo "Installing Open MPI RPM"
 sudo rpm -Uvh ${bin_rpm_name}

--- a/jenkins/open-mpi.dist.create-tarball.build-rpm.sh
+++ b/jenkins/open-mpi.dist.create-tarball.build-rpm.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# usage: build-rpm.sh <build_prefix> <srpm_name>
+#
+# Script to build a binary RPM from a source RPM
+#
+# Expected filesystem layout:
+#    ${WORKSPACE}/ompi-scripts/         ompi-scripts checkout
+#    ${WORKSPACE}/ompi/                 ompi checkout @ target REF
+#    ${WORKSPACE}/dist-files/           output of build
+
+set -e
+
+build_prefix="$1"
+srpm_name="$2"
+
+aws s3 cp ${build_prefix}/${srpm_name} ${srpm_name}
+
+# Build and install PRRTE and OpenPMIX, if available
+if [[ -d ${WORKSPACE}/ompi/3rd-party/openpmix ]]; then
+    pushd ${WORKSPACE}/ompi/3rd-party/openpmix
+    ./autogen.pl; ./configure; make dist
+    cd contrib
+    tarball=$(find .. -name "*.bz2" -print)
+    rpmtopdir="${WORKSPACE}/rpmbuild" build_srpm=no build_single=yes ./buildrpm.sh $tarball
+    rpm_name=$(find ${WORKSPACE}/rpmbuild/RPMS -name "pmix*.rpm" -print)
+    sudo rpm -Uvh ${rpm_name}
+    popd
+fi
+
+if [[ -d ${WORKSPACE}/ompi/3rd-party/prrte ]]; then
+    pushd ${WORKSPACE}/ompi/3rd-party/prrte
+    ./autogen.pl; ./configure; make dist
+    cd contrib/dist/linux
+    tarball=$(find ../../.. -name "*.bz2" -print)
+    rpmtopdir="${WORKSPACE}/rpmbuild" ./buildrpm.sh -b "${tarball}"
+    rpm_name=$(find ${WORKSPACE}/rpmbuild/RPMS -name "prrte*.rpm" -print)
+    sudo rpm -Uvh ${rpm_name}
+    popd
+fi
+
+rpmbuild --rebuild ${srpm_name}
+bin_rpm_name=`find ${WORKSPACE}/rpmbuild/RPMS -name "openmpi*.rpm" -print`
+sudo rpm -Uvh ${bin_rpm_name}

--- a/jenkins/open-mpi.dist.create-tarball.groovy
+++ b/jenkins/open-mpi.dist.create-tarball.groovy
@@ -109,13 +109,14 @@ parallel (
     node(manpage_builder) {
       stage('Build Man Pages') {
 	checkout_code();
-    // Check if we need to build man pages
+    // Open MPI 5.0 and later auto-build docs on readthedocs.io, so we do not need to build manpages for www.open-mpi.org.
+    // Skip this step if we find readthedocs input files.
     if (sh(script: "test -f ${WORKSPACE}/ompi/docs/history.rst", returnStatus: true) != 0) {
         sh "ls -lR . ; /bin/bash ompi-scripts/jenkins/open-mpi.dist.create-tarball.build-manpages.sh ${build_prefix} ${tarball} ${branch}"
         artifacts = sh(returnStdout:true, script:'cat ${WORKSPACE}/manpage-build-artifacts.txt').trim()
         currentBuild.description="${currentBuild.description}<b>Manpages:</b> <A HREF=\"${artifacts}\">${artifacts}</A><BR>\n"
     } else {
-        echo "Using RST; skipping building man pages"
+        echo "Using ReadTheDocs; skipping building man pages"
     }
       }
     }


### PR DESCRIPTION
This change builds and installs openmpix and prrte from the ompi tree to ensure correct versions.

Also skips building man pages if using RST documenation.

Signed-off-by: Eric Raut <eraut@amazon.com>