### PR TITLE
Add pipeline to download coverity tools

### DIFF
--- a/jenkins/open-mpi.coverity.tool_downloader.groovy
+++ b/jenkins/open-mpi.coverity.tool_downloader.groovy
@@ -1,0 +1,18 @@
+// -*- groovy -*-
+//
+// Download the latest Coverity scan-build toolset from Coverity and put in S3
+//
+
+node('headnode') {
+  stage('Download From Coverity') {
+    withCredentials([usernamePassword(credentialsId: 'b47cf375-6e78-4f1f-b215-18a7903a4763',
+                                      passwordVariable: 'token',
+                                      usernameVariable: 'project')]) {
+      sh(label: 'Download via curl', script: '''
+        curl --fail -d "token=$token&project=$project" https://scan.coverity.com/download/cxx/linux64 --output linux64.tar.gz''')
+    }
+  }
+  stage('Upload to S3') {
+    s3Upload acl: 'Private', bucket: 'ompi-jenkins-config', file: 'linux64.tar.gz', path: 'coverity/coverity_tools.tgz'
+  }
+}


### PR DESCRIPTION
The coverity tools are large (1+ GiB) and change infrequently.  Create a pipeline intended to run weekly to move the tools from Coverity into S3, so that we don't pay ingress charges every time we run a job. Unfortunately, I can't find a way to authenticate to the download server to just call HEAD and get the download time (which would be the smarter option), so this will have to do.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>