### PR TITLE
Fix arg parsing in Coverity script

### DIFF
--- a/nightly-tarball/Coverity.py
+++ b/nightly-tarball/Coverity.py
@@ -169,7 +169,7 @@ if __name__ == '__main__':
                         help='Coverity submission email address',
                         type=str)
 
-    for key, value in vars(parser.parse_args()).iteritems():
+    for key, value in vars(parser.parse_args()).items():
         if not value == None:
             config[key] = value
 


### PR DESCRIPTION
The Coverity script still used some Python2-isms in argument parsing. These didn't matter for today's Coverity runs, since the package is called as a library from the nightly builder, but is important as part of splitting nightly tarballs and Coverity.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>