### PR TITLE
jenkins/ompi-build-script: add singletons

### DIFF
--- a/jenkins/open-mpi-build-script.sh
+++ b/jenkins/open-mpi-build-script.sh
@@ -266,34 +266,45 @@ if test "${MPIRUN_MODE}" != "none"; then
 	    exec="timeout -s SIGSEGV 4m mpirun --get-stack-traces --timeout 180 --hostfile ${WORKSPACE}/hostfile -np 2 "
 	    ;;
     esac
+    singleton="timeout -s SIGSEGV 1m "
     run_example "${exec}" ./examples/hello_c
+    run_example "${singleton}" ./examples/hello_c
     run_example "${exec}" ./examples/ring_c
+    run_example "${singleton}" ./examples/ring_c
     run_example "${exec}" ./examples/connectivity_c
     if ompi_info --parsable | grep -q bindings:cxx:yes >/dev/null; then
         echo "--> running C++ examples"
         run_example "${exec}" ./examples/hello_cxx
+        run_example "${singleton}" ./examples/hello_cxx
         run_example "${exec}" ./examples/ring_cxx
+        run_example "${singleton}" ./examples/ring_cxx
     else
         echo "--> skipping C++ examples"
     fi
     if ompi_info --parsable | grep -q bindings:mpif.h:yes >/dev/null; then
         echo "--> running mpif examples"
         run_example "${exec}" ./examples/hello_mpifh
+        run_example "${singleton}" ./examples/hello_mpifh
         run_example "${exec}" ./examples/ring_mpifh
+        run_example "${singleton}" ./examples/ring_mpifh
     else
         echo "--> skipping mpif examples"
     fi
     if ompi_info --parsable | egrep -q bindings:use_mpi:\"\?yes >/dev/null; then
         echo "--> running usempi examples"
         run_example "${exec}" ./examples/hello_usempi
+        run_example "${singleton}" ./examples/hello_usempi
         run_example "${exec}" ./examples/ring_usempi
+        run_example "${singleton}" ./examples/ring_usempi
     else
         echo "--> skipping usempi examples"
     fi
     if ompi_info --parsable | grep -q bindings:use_mpi_f08:yes >/dev/null; then
         echo "--> running usempif08 examples"
         run_example "${exec}" ./examples/hello_usempif08
+        run_example "${singleton}" ./examples/hello_usempif08
         run_example "${exec}" ./examples/ring_usempif08
+        run_example "${singleton}" ./examples/ring_usempif08
     else
         echo "--> skipping usempif08 examples"
     fi


### PR DESCRIPTION
Hey @bwbarrett -- is there a reason we don't already do singletons here in the OMPI Jenkins CI build script?  This PR adds a handful of singleton runs (of hello world and ring); I can't remember if there's a reason we don't already do this...?

I know we're moving to Jenkinsfile-based runs in the near future, but we've been talking about getting better runtime CI coverage on the Tuesday call recently, and this seemed like low-hanging fruit (even if we move to Jenkinsfile soon), especially since singleton was broken recently (i.e., within Dec 2022).

---

Add singleton runs to the Open MPI Jenkins CI build script, just for slightly better runtime coverage in CI.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

FYI @naughtont3