### PR TITLE
jenkins: Don't bind for CI tests

### DIFF
--- a/jenkins/open-mpi-build-script.sh
+++ b/jenkins/open-mpi-build-script.sh
@@ -263,7 +263,7 @@ if test "${MPIRUN_MODE}" != "none"; then
 	    exec="timeout -s SIGSEGV 3m mpirun -hostfile ${WORKSPACE}/hostfile -np 2 "
 	    ;;
 	*)
-	    exec="timeout -s SIGSEGV 4m mpirun --get-stack-traces --timeout 180 --hostfile ${WORKSPACE}/hostfile -np 2 "
+	    exec="timeout -s SIGSEGV 4m mpirun --get-stack-traces --timeout 180 --hostfile ${WORKSPACE}/hostfile -np 2 --bind-to none"
 	    ;;
     esac
     singleton="timeout -s SIGSEGV 1m "


### PR DESCRIPTION
The CI tests on the AWS jenkins instance all run on instances with 1 core.  There's a special case in OMPI to bind to core for a 2 process run for benchmarking reasons, and this was causing failures in mapping because there aren't 2 cores on the instance.  So instead turn off binding for these small tests.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>