### PR TITLE
BuilderUtils.py: default to more logging output

### DIFF
--- a/nightly-tarball/BuilderUtils.py
+++ b/nightly-tarball/BuilderUtils.py
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2017      Amazon.com, Inc. or its affiliates.  All Rights
 #                         Reserved.
+# Copyright (c) 2024      Jeffrey M. Squyres.  All rights reserved.
 #
 # Additional copyrights may follow
 #
@@ -14,7 +15,7 @@ import fileinput
 def logged_call(args,
                 wrapper_args=None,
                 log_file=None,
-                err_log_len=20,
+                err_log_len=30,
                 env=None):
     """Wrapper around check_call to log output
 


### PR DESCRIPTION
For quite a while, the build-with-autotools Open MPI nightly build on Open MPI v5.0.0 has been failing.  It turns out that upstream PMIx upgraded the version of Sphinx that it required, which ultimately caused the build failure because the Sphinx version installed on aws.open-mpi.org was too old.  Upgrading the Sphinx on aws.open-mpi.org was easy enough.

The real issue is that the failure notification email did not include enough logging output to reveal that the root cause of the build failure was the Sphinx version.  As such, this commit increases the default number of log lines included in the failure message in the email so that this particular problem, at least, will be evident in future emails.