### PR TITLE
jenkins: FreeBSD link BASH to /bin/bash

### DIFF
--- a/jenkins/customize-ami.sh
+++ b/jenkins/customize-ami.sh
@@ -381,6 +381,11 @@ case $PLATFORM_ID in
                 exit 1
                 ;;
         esac
+
+        if test ! -r /bin/bash ; then
+            sudo ln -s /usr/local/bin/bash /bin/bash
+        fi
+
         ;;
     *)
         echo "ERROR: Unkonwn platform ${PLATFORM_ID}"


### PR DESCRIPTION
The CI scripts assume /bin/bash exists, but FreeBSD installs BASH in /usr/local/bin/bash.  Create a symlink to try to keep CI happy.