### PR TITLE
jenkins: Add Ubuntu 26, RHEL 9/10 AMIs

### DIFF
--- a/jenkins/customize-ami.sh
+++ b/jenkins/customize-ami.sh
@@ -139,6 +139,21 @@ case $PLATFORM_ID in
                 sudo ${PIP_CMD} install sphinx recommonmark docutils sphinx-rtd-theme sphobjinv
                 labels="${labels} linux rhel8 rhel8-${arch}"
                 ;;
+            9.*)
+                sudo yum -y install python3 \
+                  gcc gcc-c++ gcc-gfortran \
+                  java-21-openjdk-headless
+                sudo yum -y remove java-1.8.0-openjdk-headless
+                PIP_CMD=pip3
+                labels="${labels} linux rhel9 rhel9-${arch}"
+                ;;
+            10.*)
+                sudo yum -y install python3 \
+                  gcc gcc-c++ gcc-gfortran \
+                  java-25-openjdk-headless
+                PIP_CMD=pip3
+                labels="${labels} linux rhel10 rhel10-${arch}"
+                ;;
             *)
                 echo "ERROR: Unknown version ${PLATFORM_ID} ${VERSION_ID}"
                 exit 1
@@ -313,12 +328,50 @@ case $PLATFORM_ID in
                     echo "AMI_clang${i}_CPP=clang-cpp-${i}" >> ${ompi_compiler_script}
                     echo "AMI_clang${i}_CXX=clang++-${i}" >> ${ompi_compiler_script}
                     echo "AMI_clang${i}_FC=flang-new-${i}" >> ${ompi_compiler_script}
-                    labels="${labels} clang{i}"
+                    labels="${labels} clang${i}"
                 done
                 if test "$arch" = "x86_64" ; then
                     sudo DEBIAN_FRONTEND=noninteractive apt-get -y install gcc-multilib g++-multilib gfortran-multilib
                     labels="${labels} 32bit_builds"
                 fi
+                ;;
+            26.04)
+                # we skip clang 20, because Ubuntu's 26.04 doesn't allow flang
+                # 20 and flang 21 to be installed at the same time.
+                sudo DEBIAN_FRONTEND=noninteractive apt-get -y install \
+                     python3-boto3 python3-mock \
+                     python3-pip python3-venv openjdk-25-jdk-headless \
+                     gcc-11 g++-11 gfortran-11 \
+                     gcc-12 g++-12 gfortran-12 \
+                     gcc-13 g++-13 gfortran-13 \
+                     gcc-14 g++-14 gfortran-14 \
+                     gcc-15 g++-15 gfortran-15 \
+                     clang-17 flang-17 clang-18 flang-18 \
+                     clang-19 flang-19 \
+                     clang-21 flang-21 \
+                     clang-format bsdutils unzip
+                ( cd $HOME
+                  curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+                  unzip awscliv2.zip
+                  sudo ./aws/install
+                  rm -rf awscliv2.zip aws
+                )
+                for i in 11 12 13 14 15; do
+                    echo "AMI_gcc${i}_CONFIG=1" >> ${ompi_compiler_script}
+                    echo "AMI_gcc${i}_CC=gcc-${i}" >> ${ompi_compiler_script}
+                    echo "AMI_gcc${i}_CPP=cpp-${i}" >> ${ompi_compiler_script}
+                    echo "AMI_gcc${i}_CXX=g++-${i}" >> ${ompi_compiler_script}
+                    echo "AMI_gcc${i}_FC=gfortran-${i}" >> ${ompi_compiler_script}
+                    labels="${labels} gcc${i}"
+                done
+                for i in 17 18 19 21 ; do
+                    echo "AMI_clang${i}_CONFIG=1" >> ${ompi_compiler_script}
+                    echo "AMI_clang${i}_CC=clang-${i}" >> ${ompi_compiler_script}
+                    echo "AMI_clang${i}_CPP=clang-cpp-${i}" >> ${ompi_compiler_script}
+                    echo "AMI_clang${i}_CXX=clang++-${i}" >> ${ompi_compiler_script}
+                    echo "AMI_clang${i}_FC=flang-new-${i}" >> ${ompi_compiler_script}
+                    labels="${labels} clang${i}"
+                done
                 ;;
             *)
                 echo "ERROR: Unknown version ${PLATFORM_ID} ${VERSION_ID}"
@@ -343,6 +396,12 @@ case $PLATFORM_ID in
                 sudo ${PIP_CMD} install sphinx recommonmark docutils sphinx-rtd-theme \
 		     importlib_resources dataclasses sphobjinv
                 labels="${labels} linux sles_15-${arch}"
+                ;;
+            16.*)
+                sudo zypper -n install \
+                     java-25-openjdk-headless \
+                     python3-pip
+                labels="${labels} linux sles_16-${arch}"
                 ;;
             *)
                 echo "ERROR: Unknown version ${PLATFORM_ID} ${VERSION_ID}"

--- a/jenkins/jenkins-amis.pkr.hcl
+++ b/jenkins/jenkins-amis.pkr.hcl
@@ -316,6 +316,170 @@ source "amazon-ebs" "RHEL8-x86" {
 }
 
 
+data "amazon-ami" "RHEL9-arm64" {
+  filters = {
+    architecture        = "arm64"
+    name                = "RHEL-9.7.0_HVM-*-Hourly2-GP3"
+    root-device-type    = "ebs"
+    virtualization-type = "hvm"
+  }
+  most_recent = true
+  owners      = ["309956199498"]
+  region      = "us-west-2"
+  include_deprecated = true
+}
+
+source "amazon-ebs" "RHEL9-arm64" {
+  ami_block_device_mappings {
+    delete_on_termination = true
+    device_name           = "/dev/sda1"
+    volume_size           = 16
+  }
+  ami_name                    = "Jenkins RHEL 9 arm64 ${var.build_date}"
+  deprecate_at                = "${var.deprecation_date}"
+  associate_public_ip_address = true
+  ena_support                 = true
+  iam_instance_profile        = "${var.iam_role}"
+  instance_type               = "t4g.large"
+  launch_block_device_mappings {
+    delete_on_termination = true
+    device_name           = "/dev/sda1"
+    volume_size           = 16
+  }
+  region       = "us-west-2"
+  source_ami   = "${data.amazon-ami.RHEL9-arm64.id}"
+  ssh_pty      = true
+  ssh_username = "ec2-user"
+  tags = {
+    BuildType = "${var.BuildType}",
+    JenkinsBuilderAmi = "True"
+  }
+}
+
+
+data "amazon-ami" "RHEL9-x86" {
+  filters = {
+    architecture        = "x86_64"
+    name                = "RHEL-9.7.0_HVM-*-Hourly2-GP3"
+    root-device-type    = "ebs"
+    virtualization-type = "hvm"
+  }
+  most_recent = true
+  owners      = ["309956199498"]
+  region      = "us-west-2"
+  include_deprecated = true
+}
+
+source "amazon-ebs" "RHEL9-x86" {
+  ami_block_device_mappings {
+    delete_on_termination = true
+    device_name           = "/dev/sda1"
+    volume_size           = 16
+  }
+  ami_name                    = "Jenkins RHEL 9 x86_64 ${var.build_date}"
+  deprecate_at                = "${var.deprecation_date}"
+  associate_public_ip_address = true
+  ena_support                 = true
+  iam_instance_profile        = "${var.iam_role}"
+  instance_type               = "t3.large"
+  launch_block_device_mappings {
+    delete_on_termination = true
+    device_name           = "/dev/sda1"
+    volume_size           = 16
+  }
+  region       = "us-west-2"
+  source_ami   = "${data.amazon-ami.RHEL9-x86.id}"
+  ssh_pty      = true
+  ssh_username = "ec2-user"
+  tags = {
+    BuildType = "${var.BuildType}",
+    JenkinsBuilderAmi = "True"
+  }
+}
+
+
+data "amazon-ami" "RHEL10-arm64" {
+  filters = {
+    architecture        = "arm64"
+    name                = "RHEL-10.1.0_HVM-*-Hourly2-GP3"
+    root-device-type    = "ebs"
+    virtualization-type = "hvm"
+  }
+  most_recent = true
+  owners      = ["309956199498"]
+  region      = "us-west-2"
+  include_deprecated = true
+}
+
+source "amazon-ebs" "RHEL10-arm64" {
+  ami_block_device_mappings {
+    delete_on_termination = true
+    device_name           = "/dev/sda1"
+    volume_size           = 16
+  }
+  ami_name                    = "Jenkins RHEL 10 arm64 ${var.build_date}"
+  deprecate_at                = "${var.deprecation_date}"
+  associate_public_ip_address = true
+  ena_support                 = true
+  iam_instance_profile        = "${var.iam_role}"
+  instance_type               = "t4g.large"
+  launch_block_device_mappings {
+    delete_on_termination = true
+    device_name           = "/dev/sda1"
+    volume_size           = 16
+  }
+  region       = "us-west-2"
+  source_ami   = "${data.amazon-ami.RHEL10-arm64.id}"
+  ssh_pty      = true
+  ssh_username = "ec2-user"
+  tags = {
+    BuildType = "${var.BuildType}",
+    JenkinsBuilderAmi = "True"
+  }
+}
+
+
+data "amazon-ami" "RHEL10-x86" {
+  filters = {
+    architecture        = "x86_64"
+    name                = "RHEL-10.1.0_HVM-*-Hourly2-GP3"
+    root-device-type    = "ebs"
+    virtualization-type = "hvm"
+  }
+  most_recent = true
+  owners      = ["309956199498"]
+  region      = "us-west-2"
+  include_deprecated = true
+}
+
+source "amazon-ebs" "RHEL10-x86" {
+  ami_block_device_mappings {
+    delete_on_termination = true
+    device_name           = "/dev/sda1"
+    volume_size           = 16
+  }
+  ami_name                    = "Jenkins RHEL 10 x86_64 ${var.build_date}"
+  deprecate_at                = "${var.deprecation_date}"
+  associate_public_ip_address = true
+  ena_support                 = true
+  iam_instance_profile        = "${var.iam_role}"
+  instance_type               = "t3.large"
+  launch_block_device_mappings {
+    delete_on_termination = true
+    device_name           = "/dev/sda1"
+    volume_size           = 16
+  }
+  region       = "us-west-2"
+  source_ami   = "${data.amazon-ami.RHEL10-x86.id}"
+  ssh_pty      = true
+  ssh_username = "ec2-user"
+  tags = {
+    BuildType = "${var.BuildType}",
+    JenkinsBuilderAmi = "True"
+  }
+}
+
+
 ################################################################################
 #
 # SUSE Linux Enterprise Server
@@ -352,6 +516,45 @@ source "amazon-ebs" "SLES15-x86" {
   }
   region       = "us-west-2"
   source_ami   = "${data.amazon-ami.SLES15-x86.id}"
+  ssh_pty      = true
+  ssh_username = "ec2-user"
+  tags = {
+    BuildType = "${var.BuildType}",
+    JenkinsBuilderAmi = "True"
+  }
+}
+
+data "amazon-ami" "SLES16-x86" {
+  filters = {
+    architecture        = "x86_64"
+    name                = "suse-sles-16-0-v????????-hvm-ssd*"
+    root-device-type    = "ebs"
+    virtualization-type = "hvm"
+  }
+  most_recent = true
+  owners      = ["amazon"]
+  region      = "us-west-2"
+}
+
+source "amazon-ebs" "SLES16-x86" {
+  ami_block_device_mappings {
+    delete_on_termination = true
+    device_name           = "/dev/sda1"
+    volume_size           = 16
+  }
+  ami_name                    = "Jenkins SLES 16 x86_64 ${var.build_date}"
+  deprecate_at                = "${var.deprecation_date}"
+  associate_public_ip_address = true
+  ena_support                 = true
+  iam_instance_profile        = "${var.iam_role}"
+  instance_type               = "t3.large"
+  launch_block_device_mappings {
+    delete_on_termination = true
+    device_name           = "/dev/sda1"
+    volume_size           = 16
+  }
+  region       = "us-west-2"
+  source_ami   = "${data.amazon-ami.SLES16-x86.id}"
   ssh_pty      = true
   ssh_username = "ec2-user"
   tags = {
@@ -606,6 +809,72 @@ source "amazon-ebs" "Ubuntu2404-x86" {
 }
 
 
+data "amazon-parameterstore" "Ubuntu2604-arm64" {
+  name = "/aws/service/canonical/ubuntu/server/resolute/stable/current/arm64/hvm/ebs-gp3/ami-id"
+  region = "us-west-2"
+}
+
+source "amazon-ebs" "Ubuntu2604-arm64" {
+  ami_block_device_mappings {
+    delete_on_termination = true
+    device_name           = "/dev/sda1"
+    volume_size           = 16
+  }
+  ami_name                    = "Jenkins Ubuntu 26.04 arm64 ${var.build_date}"
+  deprecate_at                = "${var.deprecation_date}"
+  associate_public_ip_address = true
+  ena_support                 = true
+  iam_instance_profile        = "${var.iam_role}"
+  instance_type               = "t4g.large"
+  launch_block_device_mappings {
+    delete_on_termination = true
+    device_name           = "/dev/sda1"
+    volume_size           = 16
+  }
+  region       = "us-west-2"
+  source_ami   = "${data.amazon-parameterstore.Ubuntu2604-arm64.value}"
+  ssh_pty      = true
+  ssh_username = "ubuntu"
+  tags = {
+    BuildType = "${var.BuildType}",
+    JenkinsBuilderAmi = "True"
+  }
+}
+
+
+data "amazon-parameterstore" "Ubuntu2604-x86" {
+  name = "/aws/service/canonical/ubuntu/server/resolute/stable/current/amd64/hvm/ebs-gp3/ami-id"
+  region = "us-west-2"
+}
+
+source "amazon-ebs" "Ubuntu2604-x86" {
+  ami_block_device_mappings {
+    delete_on_termination = true
+    device_name           = "/dev/sda1"
+    volume_size           = 16
+  }
+  ami_name                    = "Jenkins Ubuntu 26.04 x86_64 ${var.build_date}"
+  deprecate_at                = "${var.deprecation_date}"
+  associate_public_ip_address = true
+  ena_support                 = true
+  iam_instance_profile        = "${var.iam_role}"
+  instance_type               = "t3.large"
+  launch_block_device_mappings {
+    delete_on_termination = true
+    device_name           = "/dev/sda1"
+    volume_size           = 16
+  }
+  region       = "us-west-2"
+  source_ami   = "${data.amazon-parameterstore.Ubuntu2604-x86.value}"
+  ssh_pty      = true
+  ssh_username = "ubuntu"
+  tags = {
+    BuildType = "${var.BuildType}",
+    JenkinsBuilderAmi = "True"
+  }
+}
+
+
 build {
   sources = [
     "source.amazon-ebs.AmazonLinux2-arm64",
@@ -615,13 +884,19 @@ build {
     "source.amazon-ebs.FreeBSD15-x86",
     "source.amazon-ebs.RHEL8-arm64",
     "source.amazon-ebs.RHEL8-x86",
+    "source.amazon-ebs.RHEL9-arm64",
+    "source.amazon-ebs.RHEL9-x86",
+    "source.amazon-ebs.RHEL10-arm64",
+    "source.amazon-ebs.RHEL10-x86",
     "source.amazon-ebs.SLES15-x86",
     "source.amazon-ebs.Ubuntu2004-arm64",
     "source.amazon-ebs.Ubuntu2004-x86",
     "source.amazon-ebs.Ubuntu2204-arm64",
     "source.amazon-ebs.Ubuntu2204-x86",
     "source.amazon-ebs.Ubuntu2404-arm64",
-    "source.amazon-ebs.Ubuntu2404-x86"
+    "source.amazon-ebs.Ubuntu2404-x86",
+    "source.amazon-ebs.Ubuntu2604-arm64",
+    "source.amazon-ebs.Ubuntu2604-x86"
   ]
 
   provisioner "shell" {


### PR DESCRIPTION
Add ability to build Jenkins CI AMIs for Ubuntu 26.04 (x86/arm64), RHEL 9 (x86/arm64), and RHEL 10 (x86/arm64).  With this change, we are at the latest release of most of the distros (SUSE excluded).

There is something broken with the base SLES 16 AMI that causes it to puke during initialization due to Flake errors, so skip for now.