### PR TITLE
Run Automake checks with verbose output

### DIFF
--- a/jenkins/customize-ami.sh
+++ b/jenkins/customize-ami.sh
@@ -514,7 +514,7 @@ if test $run_test != 0; then
     ./configure --prefix=$HOME/install
     ${MAKE_CMD} -j 4 all
     if test "${skip_make_check}" = "0" ; then
-        ${MAKE_CMD} check
+        ${MAKE_CMD} check VERBOSE=1
     fi
     ${MAKE_CMD} install
     if test "${skip_make_dist}" = "0" ; then

--- a/jenkins/customize-ami.sh
+++ b/jenkins/customize-ami.sh
@@ -512,7 +512,7 @@ if test $run_test != 0; then
     cd ${HOME}/ompi
     ./autogen.pl
     ./configure --prefix=$HOME/install
-    ${MAKE_CMD} -j 4 all
+    ${MAKE_CMD} -j 4 all V=1
     if test "${skip_make_check}" = "0" ; then
         ${MAKE_CMD} check VERBOSE=1
     fi

--- a/jenkins/open-mpi-build-script.sh
+++ b/jenkins/open-mpi-build-script.sh
@@ -206,14 +206,14 @@ fi
 # the build-in make check tests.
 if test "${MAKE_DISTCHECK}" != ""; then
     echo "--> running make ${MAKE_ARGS} distcheck"
-    make ${MAKE_ARGS} distcheck
+    make ${MAKE_ARGS} distcheck VERBOSE=1
     exit 0
 fi
 
 echo "--> running make ${MAKE_J} ${MAKE_ARGS} all"
 make ${MAKE_J} ${MAKE_ARGS} all
 echo "--> running make check"
-make ${MAKE_ARGS} check
+make ${MAKE_ARGS} check VERBOSE=1
 echo "--> running make install"
 make ${MAKE_ARGS} install
 

--- a/jenkins/open-mpi-build-script.sh
+++ b/jenkins/open-mpi-build-script.sh
@@ -211,7 +211,7 @@ if test "${MAKE_DISTCHECK}" != ""; then
 fi
 
 echo "--> running make ${MAKE_J} ${MAKE_ARGS} all"
-make ${MAKE_J} ${MAKE_ARGS} all
+make ${MAKE_J} ${MAKE_ARGS} all V=1
 echo "--> running make check"
 make ${MAKE_ARGS} check VERBOSE=1
 echo "--> running make install"
@@ -231,7 +231,7 @@ ompi_info
 
 echo "--> running make all in examples"
 cd "${WORKSPACE}/src/examples"
-make ${MAKE_ARGS} all
+make ${MAKE_ARGS} all V=1
 cd ..
 
 # it's hard to determine what the failure was and there's no printing

--- a/jenkins/open-mpi.dist.create-tarball.groovy
+++ b/jenkins/open-mpi.dist.create-tarball.groovy
@@ -153,7 +153,7 @@ make distcheck VERBOSE=1"""
 tar xf ${tarball}
 cd openmpi-*
 ./configure --prefix=$WORKSPACE/openmpi-install
-make -j 8 all
+make -j 8 all V=1
 make check VERBOSE=1
 make install"""
       }

--- a/jenkins/open-mpi.dist.create-tarball.groovy
+++ b/jenkins/open-mpi.dist.create-tarball.groovy
@@ -130,7 +130,7 @@ parallel (
 tar xf ${tarball}
 cd openmpi-*
 ./configure
-make distcheck"""
+make distcheck VERBOSE=1"""
       }
     }
   },
@@ -154,7 +154,7 @@ tar xf ${tarball}
 cd openmpi-*
 ./configure --prefix=$WORKSPACE/openmpi-install
 make -j 8 all
-make check
+make check VERBOSE=1
 make install"""
       }
     }

--- a/nightly-tarball/Builder.py
+++ b/nightly-tarball/Builder.py
@@ -420,7 +420,7 @@ class Builder(object):
             else:
                 self.call(["autoreconf", "-if"], build_call=True)
                 self.call(["./configure"], build_call=True)
-                self.call(["make", "distcheck"], build_call=True)
+                self.call(["make", "distcheck", "VERBOSE=1"], build_call=True)
         finally:
             os.chdir(cwd)
 

--- a/nightly-tarball/OMPIBuilder.py
+++ b/nightly-tarball/OMPIBuilder.py
@@ -88,7 +88,7 @@ class OMPIBuilder(Builder.Builder):
             # setup, we don't.  But be advised that this may need to change in the
             # future...
             child_env['LD_LIBRARY_PATH'] = ''
-            self.call(['make', 'distcheck'], build_call=True, env=child_env)
+            self.call(['make', 'distcheck', 'VERBOSE=1'], build_call=True, env=child_env)
         finally:
             os.chdir(cwd)
 

--- a/nightly-tarball/hwloc-nightly-tarball
+++ b/nightly-tarball/hwloc-nightly-tarball
@@ -31,7 +31,7 @@ config_data = { 'project_name' : 'hwloc',
                                'project_name' : 'hwloc',
                                'project_prefix' : 'hwloc',
                                'configure_args' : '',
-                               'make_args' : '-j 8 check',
+                               'make_args' : '-j 8 check VERBOSE=1',
                                'email' : 'brice.goglin@labri.fr' },
                 'branches' : { 'master' : { 'output_location' : 'master/',
                                             'coverity' : False,
@@ -103,7 +103,7 @@ class HwlocBuilder(OMPIBuilder.OMPIBuilder):
             # future...
             child_env['LD_LIBRARY_PATH'] = ''
             self.call(['make', 'doc'], build_call=True, env=child_env)
-            self.call(['make', 'distcheck'], build_call=True, env=child_env)
+            self.call(['make', 'distcheck', 'VERBOSE=1'], build_call=True, env=child_env)
         finally:
             os.chdir(cwd)
 


### PR DESCRIPTION
Pass VERBOSE=1 as the final argument to scripted make check and make distcheck invocations. This covers the Jenkins jobs, nightly tarball builders, hwloc Coverity build arguments, and the AMI customization compile test.

Automake's test harness emits more detailed output when VERBOSE=1 is set, especially when tests fail. That extra output is important in CI because the job log is often the only artifact readily available; we do not have access to the individual Automake failed <test>.log files after the run has completed.

Set VERBOSE=1 on the make command line instead of trying to export it from Makefile.am. GNU Make supports the common VERBOSE=1 / export VERBOSE mechanism, but BSD Make does not support "export" (including it will cause BSD Make to fail), so relying on that approach is not portable.