### PR TITLE
ompi nightly tarball builder - use python venv

### DIFF
--- a/nightly-tarball/run-with-autotools.sh
+++ b/nightly-tarball/run-with-autotools.sh
@@ -36,4 +36,24 @@ fi
 module unload autotools
 module load $module_name
 
+#
+# in addition to all the autotools modules, recent 
+# Open MPI branches need a number of python modules 
+# not all of which are available via linux distros,
+# so set up a virtual env to run the command in
+#
+REQ_FILE=""
+if [ -f "${PWD}/requirements.txt" ]; then
+    REQ_FILE="${PWD}/requirements.txt"
+elif [ -f "${PWD}/docs/requirements.txt" ]; then
+    REQ_FILE="${PWD}/docs/requirements.txt"
+fi
+if [ -n "$REQ_FILE" ]; then
+    python3 -m venv ompi-docs-venv
+    . ompi-docs-venv/bin/activate
+    pip3 install -r $REQ_FILE
+fi
 $program_name "${arguments[*]}"
+if [ -n "${VIRTUAL_ENV:-}" ] && command -v deactivate >/dev/null 2>&1; then
+    deactivate
+fi


### PR DESCRIPTION
since we now rely on sphinx python modules that are not available via linux package managers.

This patch reenables nightly tarball builds which had not been happening since mid January 2026.